### PR TITLE
fixed tab bug to work w/o entering messages

### DIFF
--- a/src/components/Pages/TrainingSeries/List/Tab/Tab.js
+++ b/src/components/Pages/TrainingSeries/List/Tab/Tab.js
@@ -34,7 +34,6 @@ function Tab({
         const tsMessages = messages.filter(msg => {
           return msg.training_series_id === id;
         });
-        let selectedId = tsMessages[0].id;
         const daysLong = Math.max(...tsMessages.map(m => m.days_from_start));
 
         return (
@@ -59,7 +58,7 @@ function Tab({
 
                     <Select
                       onChange={e => {
-                        selectedId = parseInt(e.target.value);
+                        tsMessages[0].id = parseInt(e.target.value);
                       }}
                       onClick={e => {
                         e.stopPropagation();
@@ -80,7 +79,7 @@ function Tab({
                       type="submit"
                       onClick={e => {
                         e.stopPropagation();
-                        history.push(`/home/message/${selectedId}`);
+                        history.push(`/home/message/${tsMessages[0].id}`);
                       }}
                     >
                       Go to Message


### PR DESCRIPTION
# Description
Fixed a bug for the home page when creating a new training series without inputting a message, the page would crash. Now you can add a training series without a message and click the training series tab and it will load properly. 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Change status
- [X ] Complete, tested, ready to review and merge

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] There are no merge conflicts
