### PR TITLE
removed back button when on home page

### DIFF
--- a/src/components/Pages/Dashboard/Loader/Loader.js
+++ b/src/components/Pages/Dashboard/Loader/Loader.js
@@ -51,7 +51,7 @@ function Loader(props) {
             />
           )}
           <AppBar />
-            {props.location.pathname !== "/home/classes" && (
+            {props.location.pathname !== "/home" && (
             <ReturnToPreviousPageButton history={props.history} /> 
           )} 
           <DashboardContainer>


### PR DESCRIPTION
# Description

Redirect button shows up on the home page now which I removed because on the home page all you can redirect to is the auth /callback which isn't needed or wanted behavior, this causes the user to be stuck in a loading loop that doesn't end. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Login to the app and the back button will show up and when you click on it will redirect to /callback and cause an endless loading loop.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] There are no merge conflicts
